### PR TITLE
Fixes and enhancements.

### DIFF
--- a/sendxmpp
+++ b/sendxmpp
@@ -19,6 +19,7 @@ if 0; # not running under some shell
 
 use Authen::SASL qw(Perl); # authentication broken if Authen::SASL::Cyrus module installed
 use Net::XMPP;
+use Net::Domain;
 use Getopt::Long;
 use strict;
 
@@ -26,7 +27,7 @@ use open ':utf8';
 use open ':std';
 
 # subroutines decls
-sub xmpp_login($$$$$$$$$$$);
+sub xmpp_login($$$$$$$$$$$$);
 sub xmpp_send ($$$$);
 sub xmpp_send_raw_xml($$);
 sub xmpp_send_message($$$$$$);
@@ -66,7 +67,7 @@ sub main () {
     $VERBOSE = 1 if ($$cmdline{'verbose'});
 
     my $config = read_config_file ($$cmdline{'file'})
-	unless ($$cmdline{'username'} && $$cmdline{'password'});
+	unless ($$cmdline{'sso'} || ($$cmdline{'username'} && $$cmdline{'password'}));
 
     # login to xmpp
     my $cnx =  xmpp_login ($$cmdline{'jserver'}  || $$config{'jserver'},
@@ -79,7 +80,8 @@ sub main () {
 			   $$cmdline{'no-tls-verify'} || $$config{'no-tls-verify'},
 			   $$cmdline{'tls-ca-path'} || $$config{'tls-ca-path'} || '',
 			   $$cmdline{'ssl'},
-			   $$cmdline{'debug'})
+			   $$cmdline{'debug'},
+	                   $$cmdline{'sso'})
       or error_exit("cannot login: $!");
 
 
@@ -206,7 +208,7 @@ sub parse_cmdline () {
 
     usage() unless (scalar(@ARGV));
 
-	my ($subject,$file,$resource,$jserver,$port,$username,$password,$component,
+	my ($subject,$file,$resource,$jserver,$port,$username,$password,$sso,$component,
 	$message, $chatroom, $headline, $debug, $tls, $ssl,
 	$no_tls_verify, $tls_ca_path,
 	$interactive, $help, $raw, $verbose);
@@ -218,6 +220,7 @@ sub parse_cmdline () {
 			  'component|o=s'  => \$component,
 			  'username|u=s'   => \$username,
 			  'password|p=s'   => \$password,
+			  'sso'            => \$sso,
 			  'message|m=s'    => \$message,
 			  'headline|l'     => \$headline,
 			  'message-type=s' => \$message_type,
@@ -257,6 +260,10 @@ sub parse_cmdline () {
 	    error_exit("Connect securely wether using -e (--ssl) or -t (--tls)");
 	}
 
+        if ($sso && $username) {
+	    error_exit("When using --sso, user should not be specified");
+        }
+
 	if ($headline) {
 		# --headline withouth --message-type
 		if ($message_type eq 'message') {
@@ -280,6 +287,7 @@ sub parse_cmdline () {
 		'port'        => ($port or 0),
 		'username'    => ($username or ''),
 		'password'    => ($password or ''),
+		'sso'         => ($sso or 0),
 		'chatroom'    => ($chatroom or 0),
 		'message-type'    => $message_type,
 		'interactive' => ($interactive or 0),
@@ -308,9 +316,9 @@ sub parse_cmdline () {
 # input: hostname,port,username,password,resource,tls,ssl,debug
 # output: an XMPP connection object
 #
-sub xmpp_login ($$$$$$$$$$$) {
+sub xmpp_login ($$$$$$$$$$$$) {
 
-    my ($host, $port, $user, $pw, $comp, $res, $tls, $no_tls_verify, $tls_ca_path, $ssl, $debug) = @_;
+    my ($host, $port, $user, $pw, $comp, $res, $tls, $no_tls_verify, $tls_ca_path, $ssl, $debug, $sso) = @_;
     my $cnx = new Net::XMPP::Client(debuglevel=>$debug);
     error_exit "could not create XMPP client object: $!"
 	unless ($cnx);
@@ -332,6 +340,11 @@ sub xmpp_login ($$$$$$$$$$$) {
 		connectiontype	=> 'tcpip',
 		componentname	=> $comp
 	};
+
+    if ($sso) {
+	$user = join('@', scalar getpwuid($<), Net::Domain::hostdomain());
+	debug_print "using SSO user $user";
+    }
 
     # use the xmpp domain as the host and enable SRV lookups
     if (!$host) {
@@ -602,6 +615,10 @@ Use I<user> instead of the one in the configuration file
 =item B<-p>,B<--password> I<password>
 
 Use I<password> instead of the one in the configuration file
+
+=item B<--sso> 
+
+Instead of specifying username or password, attempt to use system level SSO (e.g. kerberos) if supported.
 
 =item B<-j>,B<--jserver> I<server>
 


### PR DESCRIPTION
Fixes:
- TLS flag should be passed as 0 or 1, and not undef to prevent a warning
- The Net::XMPP::Client often sets an error code itself during connection failure, so display if possible

Enhancements:
- Enable SRV lookups (make passing hostname optionsal)
- Allow higher debug level to be specified on cmd line using -d <n> or -d -d -d -d  
- Add option "--sso" which sets user (user@domain) from current OS, allows empty password
