### PR TITLE
Fix for support virtual domain user names

### DIFF
--- a/sendxmpp
+++ b/sendxmpp
@@ -355,8 +355,10 @@ sub xmpp_login ($$$$$$$$$$$$) { # {{{
 
     # use the xmpp domain as the host and enable SRV lookups
 	if (!$host) {
-		if ($user =~ /@(.*)/) {
-			$arghash->{hostname} = $host = $1;
+		if ($user =~ /([\.\w_#-]+)@(.*)/) {
+			$arghash->{hostname} = $host = $2;
+			$arghash->{componentname} = $2;
+			$user = $1;
 			$arghash->{srv} = 1;
 			debug_print "enabling SRV lookups";
 


### PR DESCRIPTION
This will allow only the user ID in the form `<user>`@`<domain>` and password without additional parameters such as component and/or jserver. Google App account `<user>`@`<my domain>` work fine, as well as Gmail account `<user>`@gmail.com.